### PR TITLE
Unable to obtain editorRef.current.monaco

### DIFF
--- a/packages/admin/src/components/Editor/MonacoEditor.tsx
+++ b/packages/admin/src/components/Editor/MonacoEditor.tsx
@@ -87,7 +87,7 @@ const _MonacoEditor = (props, ref) => {
 
   useImperativeHandle(ref, () => ({
     editor: editorRef.current,
-    monoca: monacoRef.current,
+    monaco: monacoRef.current,
   }));
 
   useEffect(() => {

--- a/packages/admin/src/components/Editor/toolbar/AddCode.tsx
+++ b/packages/admin/src/components/Editor/toolbar/AddCode.tsx
@@ -1,0 +1,43 @@
+import { Tooltip } from 'antd';
+import React, { useCallback } from 'react';
+
+export const AddCode = ({ editor, monaco }) => {
+  const codeBlock = (selectText) => {
+    return `\`\`\`js\n${selectText}\n\`\`\``;
+  };
+
+  const insert = useCallback(() => {
+    const s = editor.getSelection();
+    //获取选中文本
+    const selectText = editor.getModel().getValueInRange(editor.getSelection());
+    const RangeObj = new monaco.Range(s.startLineNumber, s.startColumn, s.endLineNumber, s.endColumn);
+
+    editor.executeEdits('', [
+      {
+        range: RangeObj,
+        text: codeBlock(selectText),
+      },
+    ]);
+  }, [editor, monaco]);
+
+  return (
+    <Tooltip title={'添加代码块'}>
+      <svg
+        onClick={insert}
+        className="icon"
+        viewBox="0 0 1024 1024"
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        p-id="13552"
+        width="16px"
+        height="16px"
+      >
+        <path
+          d="M810.666667 341.333333c0-202.069333-139.477333-255.829333-213.248-256l-0.554667 85.333334c13.141333 0.256 128.469333 7.381333 128.469333 170.666666 0 85.034667 35.456 138.496 80.085334 170.666667-44.629333 32.170667-80.085333 85.632-80.085334 170.666667 0 163.285333-115.328 170.410667-128.469333 170.666666L597.333333 896l0.085334 42.666667C671.189333 938.496 810.666667 884.736 810.666667 682.666667c0-120.448 106.837333-127.744 128-128l0.256-85.333334C917.504 469.077333 810.666667 461.781333 810.666667 341.333333zM213.333333 682.666667c0 202.069333 139.477333 255.829333 213.248 256l0.554667-85.333334C413.994667 853.077333 298.666667 845.952 298.666667 682.666667c0-85.034667-35.456-138.496-80.085334-170.666667C263.210667 479.829333 298.666667 426.368 298.666667 341.333333c0-163.285333 115.328-170.410667 128.469333-170.666666L426.666667 128l-0.085334-42.666667C352.810667 85.504 213.333333 139.264 213.333333 341.333333c0 120.448-106.837333 127.744-128 128l-0.256 85.333334c21.418667 0.256 128.256 7.552 128.256 128z"
+          fill="currentColor"
+          p-id="13553"
+        ></path>
+      </svg>
+    </Tooltip>
+  );
+};

--- a/packages/admin/src/components/Editor/toolbar/Magimg.tsx
+++ b/packages/admin/src/components/Editor/toolbar/Magimg.tsx
@@ -1,0 +1,66 @@
+import { Popover, Tooltip } from 'antd';
+import React, { useCallback } from 'react';
+
+const magConfig = ['30%', '60%', '90%'];
+
+const imgTag = (url = null, size) => {
+  return `<img src="${url.trim()}" style="width:${size}"></img>`;
+};
+
+export const Magimg = ({ editor, monaco }) => {
+  const insert = useCallback(
+    (size) => {
+      const s = editor.getSelection();
+      //获取选中文本
+      const selectText = editor.getModel().getValueInRange(editor.getSelection());
+      const RangeObj = new monaco.Range(s.startLineNumber, s.startColumn, s.endLineNumber, s.endColumn);
+
+      editor.executeEdits('', [
+        {
+          range: RangeObj,
+          text: imgTag(selectText, size),
+        },
+      ]);
+    },
+    [editor, monaco]
+  );
+
+  return (
+    <Popover
+      content={
+        <ul>
+          {magConfig.map((size, index) => {
+            return (
+              <li style={{ cursor: 'pointer' }} key={index} onClick={() => insert(size)}>
+                {size}
+              </li>
+            );
+          })}
+        </ul>
+      }
+    >
+      <Tooltip title={'放大图片'}>
+        <svg
+          className="icon"
+          viewBox="0 0 1024 1024"
+          version="1.1"
+          xmlns="http://www.w3.org/2000/svg"
+          p-id="12316"
+          width="16px"
+          height="16px"
+        >
+          <path
+            fill="currentColor"
+            d="M856.32 428.064c-94.816 0-144.928 90.656-185.184 163.52-25.824 46.688-52.512 94.944-78.72 97.568-28.544-5.664-48.096-23.2-70.656-43.36-31.744-28.448-67.488-60.288-130.464-57.952-76.8 3.328-146.24 57.696-206.4 161.696a32 32 0 0 0 55.392 32.064c48.48-83.84 100.224-127.488 153.728-129.824 36.928-1.44 56.96 16.576 84.992 41.664 26.88 24.096 57.344 51.36 105.888 59.392a31.584 31.584 0 0 0 5.216 0.448c64.704 0 101.44-66.464 136.96-130.72 28.352-51.328 57.504-104 97.184-123.072v369.984H128V231.68h488.16a32 32 0 1 0 0-64H96a32 32 0 0 0-32 32v701.824a32 32 0 0 0 32 32h760.32a32 32 0 0 0 32-32V460.064a32 32 0 0 0-32-32z"
+            p-id="12317"
+          ></path>
+          <path
+            fill="currentColor"
+            d="M180.96 424.32c0 57.952 47.168 105.12 105.12 105.12s105.12-47.168 105.12-105.12-47.168-105.088-105.12-105.088-105.12 47.136-105.12 105.088z m146.24 0a41.152 41.152 0 0 1-82.24 0 41.152 41.152 0 0 1 82.24 0zM960 174.656h-61.376V113.28a32 32 0 1 0-64 0v61.344H752.64a32 32 0 1 0 0 64h81.984v81.984a32 32 0 1 0 64 0V238.656H960a32 32 0 1 0 0-64z"
+            p-id="12318"
+          ></path>
+        </svg>
+      </Tooltip>
+    </Popover>
+  );
+};

--- a/packages/admin/src/components/Editor/toolbar/index.tsx
+++ b/packages/admin/src/components/Editor/toolbar/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 
+import { AddCode } from './AddCode';
 import { Emoji } from './Emoji';
 import { File } from './File';
 import { Iframe } from './Iframe';
 import { Image } from './Image';
+import { Magimg } from './Magimg';
 import { Video } from './Video';
 
 export const toolbar = [
@@ -38,6 +40,20 @@ export const toolbar = [
   {
     label: '文件库',
     content: ({ editor, monaco }) => <File editor={editor} monaco={monaco} />,
+    getAction: () => () => {
+      return undefined;
+    },
+  },
+  {
+    label: '放大图片',
+    content: ({ editor, monaco }) => <Magimg editor={editor} monaco={monaco} />,
+    getAction: () => () => {
+      return undefined;
+    },
+  },
+  {
+    label: '添加代码块',
+    content: ({ editor, monaco }) => <AddCode editor={editor} monaco={monaco} />,
     getAction: () => () => {
       return undefined;
     },


### PR DESCRIPTION
## First Commit
### Problem
In 'packages\admin\src\components\Editor\index.tsx'
Unable to obtain editorRef.current.monaco
![image](https://user-images.githubusercontent.com/75024633/196915743-385431c9-e15e-46d1-a5f8-c93529a77de7.png)

### Solution
In 'packages\admin\src\components\Editor\MonacoEditor.tsx'
fix the key:
![image](https://user-images.githubusercontent.com/75024633/196916069-e7ce6183-3e1b-4fe2-87b0-6511539ad91a.png)

## Second Commit
### Add two features refer to JueJin
### magnify the picture
![1667466906558(1)](https://user-images.githubusercontent.com/75024633/199684168-027da9c2-2a0a-49f9-bcb6-6c7feab8da99.jpg)
![image](https://user-images.githubusercontent.com/75024633/199684355-1344738d-4d7e-4963-8cf5-44b6e216d953.png)

### add code block
![image](https://user-images.githubusercontent.com/75024633/199684641-73ba860a-4351-4aaf-90ab-b3f414d028e6.png)

![image](https://user-images.githubusercontent.com/75024633/199684556-ebc865d3-42e3-4f91-9c44-2a93548e6fcc.png)
